### PR TITLE
Bugfixes (surfaced while updating package)

### DIFF
--- a/HarcHardware/pom.xml
+++ b/HarcHardware/pom.xml
@@ -33,7 +33,7 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>gnu.io.</groupId>
+                    <groupId>gnu.io</groupId>
                     <artifactId>RXTX</artifactId>
                     <version>2.2pre2h</version>
                 </dependency>

--- a/IrScrutinizer/pom.xml
+++ b/IrScrutinizer/pom.xml
@@ -278,5 +278,10 @@
             <artifactId>Crystal-Clear-Icons</artifactId>
             <version>20070620</version>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.4.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -126,7 +126,7 @@
                                         com.hifiremote:ExchangeIR
                                     </exclude>
                                     <exclude>
-                                        org.harctoolbox:harctoolbox
+                                        org.harctoolbox:HarctoolboxBundle
                                     </exclude>
                                 </excludes>
                             </artifactSet>
@@ -148,7 +148,7 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.harctoolbox</groupId>
-                                    <artifactId>harctoolbox</artifactId>
+                                    <artifactId>HarctoolboxBundle</artifactId>
                                     <version>1.0.0</version>
                                     <classifier>sources</classifier>
                                     <type>tar.gz</type>
@@ -237,7 +237,7 @@
         </dependency>
         <dependency>
             <groupId>org.harctoolbox</groupId>
-            <artifactId>harctoolbox</artifactId>
+            <artifactId>HarctoolboxBundle</artifactId>
             <version>1.0.0</version>
             <type>tar.gz</type>
             <classifier>sources</classifier>


### PR DESCRIPTION
These are downstream fixes in 1.0.0-0.5.20150318gitb8a5e3c1.fc21  at https://copr.fedoraproject.org/coprs/leamas/harctoolbox/build/83577/. It builds OK, that is.