### PR TITLE
package: bugfixes due to untested pom.xml

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -47,7 +47,7 @@
                                     <artifactId>IrScrutinizer</artifactId>
                                     <version>1.1.2beta</version>
                                     <classifier>bin</classifier>
-                                    <type>tar.gz</type>
+                                    <type>zip</type>
                                     <outputDirectory> dist </outputDirectory>
                                     <includes>
                                         *.xml,*.ini,*.desktop,doc/*
@@ -96,7 +96,7 @@
                                     <artifactId>HarctoolboxBundle</artifactId>
                                     <version>1.0.0</version>
                                     <classifier>sources</classifier>
-                                    <type>tar.gz</type>
+                                    <type>zip</type>
                                 </artifactItem>
                             </artifactItems>
                             <outputDirectory>dist</outputDirectory>
@@ -232,7 +232,7 @@
             <groupId>org.harctoolbox</groupId>
             <artifactId>HarctoolboxBundle</artifactId>
             <version>1.0.0</version>
-            <type>tar.gz</type>
+            <type>zip</type>
             <classifier>sources</classifier>
         </dependency>
     </dependencies>

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -7,7 +7,7 @@
 
 mvn install:install-file \
     -DgroupId=com.hifiremote \
-    -DartifactId=DecodeIrCaller \
+    -DartifactId=DecodeIRCaller \
     -Dversion=2.44 \
     -Dpackaging=jar \
     -Dfile=$( build-classpath com.hifiremote:DecodeIrCaller )


### PR DESCRIPTION
Two trivial bugfixes. IMHO, here is two lessons. The first is how to build this from a pristine state (on fedora):
    
    $ rm -rf ~/.m2/repository
    $ tools/install-deps.sh
    $ mvn install

The second is that the Dbuilding_fedora_package flag causes these kind of errors to pass default builds unnoticed. For this reason, my basic opinion is that this flag makes no sense and should ditched. The upside (somewhat faster builds) simply does not not match the possible problems.
