### PR TITLE
Add appdata.xml (Appstream project info).

### DIFF
--- a/appdata.xml
+++ b/appdata.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+ <id>irscrutinizer.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-3.0+</project_license>
+ <name>irscrutinizer</name>
+ <summary>Tool to catch, analyse and create infrared remotes signals</summary>
+ <description>
+  <p>
+IrScrutinizer is a powerful program for capturing, generating, analyzing,
+importing and exporting infrared (IR) signals.
+</p>
+<p>
+For capturing and sending IR signals several different hardware sensors
+and senders are supported. IR Signals can be imported not only by capturing
+from one of the supported hardware sensors (among others: IrWidget,
+Global Caché, and Arduino), but also from a number of different file formats
+(among others: LIRC, Wave, Pronto Classic and professional, RMDU (partially)
+and different text based formats; not only from files, but also from the
+clipboard, from URLs, and from file hierarchies), as well as the Internet
+IR Databases by Global Caché and by IRDB.
+</p>
+<p>
+Imported signals can be decoded, analyzed, edited, and plotted. A collection
+of IR signal can thus be assembled and edited, and finally exported in one of
+the many supported formats.
+</p>
+<p>
+In addition, the program contains the powerful IrpMaster IR-renderer, which
+means that almost all IR protocols known to the Internet community can be
+generated.
+</p>
+</description>
+ <screenshots>
+  <screenshot type="default">
+   <image>https://leamas.fedorapeople.org/appdata/harctoolbox/irscrutinizer.png</image>
+   <caption>The main window showing the application at startup</caption>
+  </screenshot>
+  <screenshot>
+  <image>http://www.harctoolbox.org/repository/scrutinize-signal.png </image>
+  <caption>Scrutinize: Identify protocol, timing, repeat patterns, etc</caption>
+  </screenshot>
+  <screenshot>
+    <image>http://www.harctoolbox.org/repository/scrutinize-remote.png</image>
+    <caption>Scrutinize remote pane: Analysis and editing of a remote</caption>
+  </screenshot>
+  <screenshot>
+    <image>http://www.harctoolbox.org/repository/export.png</image>
+    <caption>Export: signal exporting in a number of different formats</caption>
+  </screenshot>
+  <screenshot>
+    <image>http://www.harctoolbox.org/repository/import-lirc.png</image>
+    <caption>Import: remote signal importing in different formats</caption>
+  </screenshot>
+ </screenshots>
+
+ <url type="homepage">http://harctoolbox.org</url>
+ <updatecontact>https://github.com/bengtmartensson/harctoolboxbundle/issues</updatecontact>
+</component>
+


### PR DESCRIPTION
The appdata.xml file contains application data for graphical
installers. It is using a subset of the Appstream specification
which is supported by all the major Linux vendors.

Note that the file file references a file stored by me (the first, default screenshot). Since all other screenshots are stored upstream, it would be better if this also was on the same place.

Also, I had to shorten the captions which were deemed "too long" by the validation tools. Could certainly be improved, dunno.